### PR TITLE
Fixed major memory leak on closing a book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /portlibs/share
 /release.zip
 /venv
+/freetype*

--- a/source/book.cpp
+++ b/source/book.cpp
@@ -182,7 +182,9 @@ u8 Book::Open() {
 		// Restore from cache.
 		fclose(fp);
 		Restore();
+		//app->Log("CACHED");
 	} else {
+		//app->Log("UNCACHED");
 		if(format == FORMAT_XHTML) {
 			app->PrintStatus("opening XHTML...\n");
 				err = Parse(true);
@@ -197,6 +199,7 @@ u8 Book::Open() {
 		} else
 			err = 255;
 		if (app->cache) Cache();
+		fclose(fp);
 	}
 	if(!err)
 		if(position > (int)pages.size()) position = pages.size()-1;
@@ -304,9 +307,17 @@ void Book::Restore()
 		fread(buf, sizeof(char), len, fp);
 		GetPage(i)->SetBuffer(buf, len);
 	}
+	fclose(fp);
 }
 
 void Book::Close()
 {
-	pages.erase(pages.begin(), pages.end());
+	std::vector<Page*>::iterator it = pages.begin();
+	while (it != pages.end()) {
+	    delete *it;
+	    *it = nullptr;
+	    ++it;
+	}
+	pages.clear();	
+	//pages.erase(pages.begin(), pages.end());
 }


### PR DESCRIPTION
Books would not free up their pages on being destroyed. This meant that you could only open and close large books a few times before the application would crash. Now those large books can be opened and reopened to hearts content (as long as they can still individually still fit in the DSes ram :/).